### PR TITLE
Drop pkg_resources usage

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,34 +16,16 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
 
-"""Unit-test configuration for the WTSS Python Client Library for."""
+"""Unit-test for WTSS utility functions."""
 
-import json
-import os
-from pathlib import Path
-
-import pytest
-
-_JSON_PATH = Path(__file__).with_name('json')
+from wtss.utils import render_html
 
 
-@pytest.fixture
-def URL():
-    """Return the WTSS URL to be used in tests."""
-    return os.getenv('WTSS_TEST_URL', 'http://localhost')
+def test_render_html_loads_package_template():
+    """Verify packaged templates load without pkg_resources."""
+    rendered = render_html('wtss.html',
+                           url='https://example.test/wtss',
+                           coverages=['MOD13Q1'])
 
-
-@pytest.fixture
-def ListCoverageResponse():
-    """Return the list of coverages to be validated."""
-    doc = (_JSON_PATH / 'list_coverages_response.json').read_text()
-
-    return json.loads(doc)
-
-
-@pytest.fixture
-def MOD13Q1():
-    """Return the MOD13Q1 metadata."""
-    doc = (_JSON_PATH / 'describe_coverage_response.json').read_text()
-
-    return json.loads(doc)
+    assert 'https://example.test/wtss' in rendered
+    assert 'MOD13Q1' in rendered

--- a/wtss/utils.py
+++ b/wtss/utils.py
@@ -19,11 +19,11 @@
 """Utility functions for WTSS client library."""
 
 from datetime import datetime
+from pathlib import Path
 
 import jinja2
-from pkg_resources import resource_filename
 
-_template_loader = jinja2.FileSystemLoader(searchpath=resource_filename(__name__, 'templates/'))
+_template_loader = jinja2.FileSystemLoader(searchpath=Path(__file__).with_name('templates'))
 
 _template_env = jinja2.Environment(loader=_template_loader,
                                    autoescape=jinja2.select_autoescape(['html']))


### PR DESCRIPTION
## Summary
- replace runtime template lookup with a package-relative templates path
- replace test fixture JSON loading with pathlib reads
- add coverage for rendering packaged templates without pkg_resources installed

Fixes #111

## Verification
- PYTHONPATH=. /tmp/wtss-111-venv/bin/python -m pytest tests/test_utils.py -q (red before fix: ModuleNotFoundError: No module named 'pkg_resources'; green after fix: 1 passed)
- PYTHONPATH=. /tmp/wtss-111-venv/bin/python -m pytest -q (1 passed, 3 xfailed)
- PYTHONPATH=. /tmp/wtss-111-venv/bin/python -m compileall -q wtss tests
- git diff --check